### PR TITLE
Use time for overpaidPrincipal calculation during reschedule

### DIFF
--- a/Src/OpenCBS.Engine/RescheduleAssembler.cs
+++ b/Src/OpenCBS.Engine/RescheduleAssembler.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using OpenCBS.CoreDomain.Contracts.Loans.Installments;
 using OpenCBS.Engine.Interfaces;
+using OpenCBS.Shared;
 
 namespace OpenCBS.Engine
 {
@@ -24,10 +25,15 @@ namespace OpenCBS.Engine
                 where installment.ExpectedDate <= rescheduleConfiguration.StartDate
                 select installment;
 
+            var reschedulingDateTime = rescheduleConfiguration.StartDate
+                .AddHours(TimeProvider.Now.Hour)
+                .AddMinutes(TimeProvider.Now.Minute)
+                .AddSeconds(TimeProvider.Now.Second);
+            
             // Get overpaid principal = sum of paid principal after the rescheduling date...
             var overpaidPrincipal = (
                 from installment in schedule
-                where installment.PaidDate > rescheduleConfiguration.StartDate
+                where installment.PaidDate > reschedulingDateTime
                 select installment
             ).Sum(installment => installment.PaidCapital.Value);
 

--- a/Src/OpenCBS.Services/LoanServices.cs
+++ b/Src/OpenCBS.Services/LoanServices.cs
@@ -1106,10 +1106,15 @@ namespace OpenCBS.Services
                 where installment.ExpectedDate <= rescheduleConfiguration.StartDate
                 select installment;
 
+            var reschedulingDateTime = rescheduleConfiguration.StartDate
+                .AddHours(TimeProvider.Now.Hour)
+                .AddMinutes(TimeProvider.Now.Minute)
+                .AddSeconds(TimeProvider.Now.Second);
+
             // Get overpaid principal = sum of paid principal after the rescheduling date...
             var overpaidPrincipal = (
                 from installment in schedule
-                where installment.PaidDate > rescheduleConfiguration.StartDate
+                where installment.PaidDate > reschedulingDateTime
                 select installment
             ).Sum(installment => installment.PaidCapital.Value);
 


### PR DESCRIPTION
There is a bug with rescheduling. If rescheduling is performed right after repayment the capital repayment and paid capital is wrong. See ellipses in pic
![system error1](https://cloud.githubusercontent.com/assets/4609728/8923448/c18e4d16-3512-11e5-9d46-1b98225bcba8.jpg)